### PR TITLE
Enhance notification handling and UI search functionality

### DIFF
--- a/src/DPUnity.Wpf.Controls/Controls/DialogService/DPDialog.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/DialogService/DPDialog.cs
@@ -88,10 +88,18 @@ namespace DPUnity.Wpf.Controls.Controls.DialogService
 
         private static bool? ShowNotification(string message, NotificationType type = NotificationType.Information, System.Windows.Window? owner = null, string? title = null)
         {
-            var window = new Views.NotificationWindow(message, type, title)
+            var temp = owner ?? Application.Current?.MainWindow;
+            var window = new Views.NotificationWindow(message, type, title);
+
+            if (window.Owner == temp)
             {
-                Owner = owner ?? Application.Current.MainWindow
-            };
+                window.Owner = null;
+            }
+            else
+            {
+                window.Owner = owner;
+            }
+
             window.ShowDialog();
             return window.DialogResult;
         }

--- a/src/DPUnity.Wpf.Controls/Controls/ProjectSettingsMenus/ProjectSettingsMenu.xaml
+++ b/src/DPUnity.Wpf.Controls/Controls/ProjectSettingsMenus/ProjectSettingsMenu.xaml
@@ -11,6 +11,7 @@
              mc:Ignorable="d"
              d:DesignHeight="450"
              d:DesignWidth="800">
+    
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -121,180 +122,246 @@
                 </Style.Resources>
             </Style>
             <converters:BooleanToHiddenVisibilityConverter x:Key="BooleanToHiddenVisibilityConverter" />
+            <local:StringToHasValueConverter x:Key="StringToHasValueConverter" />
+
+            <SolidColorBrush x:Key="DarkPrimaryBrush"
+                             Color="#03AB54" />
         </ResourceDictionary>
     </UserControl.Resources>
+    
     <DockPanel LastChildFill="True">
         <GroupBox Header="Dự án hiện tại"
                   DockPanel.Dock="Top">
-            <TextBlock Text="Revit-Test"
+            <TextBlock Text="{Binding CurrentProjectName, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
                        HorizontalAlignment="Center"
                        Foreground="{DynamicResource DarkDangerBrush}"
                        FontWeight="Bold"
                        FontSize="18" />
         </GroupBox>
-        <GroupBox Header="Danh sách thiết lập"
-                  Margin="0 8 0 0">
+        
+        <GroupBox Header="Danh sách thiết lập">
             <DockPanel LastChildFill="True">
-                <Button Style="{DynamicResource DP_ButtonContainIcon}"
-                        Content="Thêm mới"
-                        Tag="Plus"
-                        Padding="3 3 5 3"
-                        Margin="5"
-                        HorizontalAlignment="Left"
-                        DockPanel.Dock="Top"
-                        Command="{Binding AddNewCommand, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}" />
-                <ListView Margin="0 8 0 0"
-                          Style="{DynamicResource ListViewWithoutBorder}"
-                          ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
-                          SelectedItem="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}">
-                    <ListView.ItemTemplate>
-                        <DataTemplate>
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="30" />
-                                </Grid.ColumnDefinitions>
-                                <StackPanel Orientation="Vertical">
-                                    <icons:PackIcon Kind="Ticket"
-                                                    Height="24"
-                                                    Width="14"
-                                                    Foreground="{DynamicResource PrimaryBrush}"
-                                                    Visibility="{Binding IsActivated, Converter={StaticResource BooleanToHiddenVisibilityConverter}}" />
-                                    <Button Background="Transparent"
-                                            Cursor="Hand"
-                                            Margin="0 -2 0 0"
-                                            Command="{Binding SaveCommand, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
-                                            CommandParameter="{Binding}">
+                <Grid DockPanel.Dock="Top">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Button Style="{DynamicResource DP_IconButtonStyle}"
+                            Content="Plus"
+                            Tag="Plus"
+                            Padding="3 3 5 3"
+                            Margin="3"
+                            HorizontalAlignment="Left"
+                            Command="{Binding AddNewCommand, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}" />
+                    <hc:TextBox Margin="3"
+                                Grid.Column="1"
+                                MinWidth="160"
+                                hc:InfoElement.ShowClearButton="True"
+                                hc:InfoElement.Placeholder="Tìm kiếm"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Top"
+                                Text="{Binding SearchText, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, UpdateSourceTrigger=PropertyChanged}"
+                                TextChanged="Search_TextChanged" />
+                </Grid>
+                
+                <Grid>
+                    <ListView Style="{DynamicResource ListViewWithoutBorder}"
+                              ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
+                              SelectedItem="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
+                              Visibility="{Binding HasItems, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Converter={StaticResource BooleanToHiddenVisibilityConverter}}">
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="30" />
+                                    </Grid.ColumnDefinitions>
+                                    <StackPanel Orientation="Vertical">
+                                        <icons:PackIcon Kind="Ticket"
+                                                        Height="24"
+                                                        Width="14"
+                                                        Foreground="{DynamicResource PrimaryBrush}"
+                                                        Visibility="{Binding IsActivated, Converter={StaticResource BooleanToHiddenVisibilityConverter}}" />
+                                        <Button Background="Transparent"
+                                                Cursor="Hand"
+                                                Margin="0 -2 0 0"
+                                                Command="{Binding SaveCommand, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
+                                                CommandParameter="{Binding}">
+                                            <Button.Style>
+                                                <Style TargetType="Button">
+                                                    <Setter Property="Foreground"
+                                                            Value="{DynamicResource PrimaryTextBrush}" />
+                                                    <Setter Property="Padding"
+                                                            Value="5" />
+                                                    <Setter Property="Visibility"
+                                                            Value="Collapsed" />
+                                                    <Setter Property="Template">
+                                                        <Setter.Value>
+                                                            <ControlTemplate TargetType="Button">
+                                                                <Border Background="Transparent">
+                                                                    <icons:PackIcon x:Name="icon"
+                                                                                    Kind="ContentSave"
+                                                                                    Height="14"
+                                                                                    Foreground="{TemplateBinding Foreground}"
+                                                                                    Width="14" />
+                                                                </Border>
+                                                                <ControlTemplate.Triggers>
+                                                                    <Trigger Property="IsMouseOver"
+                                                                             Value="True">
+                                                                        <Setter Property="Foreground"
+                                                                                Value="{DynamicResource PrimaryBrush}" />
+                                                                        <Setter TargetName="icon"
+                                                                                Property="Kind"
+                                                                                Value="ContentSave" />
+                                                                    </Trigger>
+                                                                    <Trigger Property="IsPressed"
+                                                                             Value="True">
+                                                                        <Setter Property="Foreground"
+                                                                                Value="{DynamicResource PrimaryBrush}" />
+                                                                        <Setter TargetName="icon"
+                                                                                Property="Kind"
+                                                                                Value="ContentSave" />
+                                                                    </Trigger>
+                                                                </ControlTemplate.Triggers>
+                                                            </ControlTemplate>
+                                                        </Setter.Value>
+                                                    </Setter>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}}"
+                                                                     Value="True">
+                                                            <Setter Property="Visibility"
+                                                                    Value="Visible" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Button.Style>
+                                        </Button>
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="1"
+                                                Orientation="Vertical"
+                                                Margin="5">
+                                        <TextBlock Text="{Binding Name}"
+                                                   TextTrimming="CharacterEllipsis">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Foreground"
+                                                            Value="{DynamicResource PrimaryTextBrush}" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}}"
+                                                                     Value="True">
+                                                            <Setter Property="FontWeight"
+                                                                    Value="Bold" />
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}}"
+                                                                     Value="True">
+                                                            <Setter Property="FontWeight"
+                                                                    Value="Bold" />
+                                                            <Setter Property="Foreground"
+                                                                    Value="{DynamicResource PrimaryBrush}" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                        <TextBlock Margin="0 4 0 0">
+                                            <InlineUIContainer>
+                                                <icons:PackIcon Kind="Update"
+                                                                Height="14"
+                                                                Width="14"
+                                                                Foreground="{DynamicResource SecondaryTextBrush}" />
+                                            </InlineUIContainer>
+                                            <Run Text="{Binding UpdatedAt, StringFormat=': {0:dd/MM/yyyy HH:mm:ss}', TargetNullValue='None'}"
+                                                 FontSize="12"
+                                                 Foreground="{DynamicResource SecondaryTextBrush}"
+                                                 BaselineAlignment="Center" />
+                                        </TextBlock>
+                                    </StackPanel>
+                                    <Button x:Name="MenuButton"
+                                            Background="Transparent"
+                                            Click="MenuButton_Click"
+                                            Grid.Column="2"
+                                            VerticalAlignment="Top"
+                                            Margin="0 5 10 0"
+                                            Cursor="Hand">
+                                        <Button.ContextMenu>
+                                            <ContextMenu Style="{DynamicResource DP_ContextMenuStyle}">
+                                                <MenuItem Header="Kích hoạt"
+                                                          itemIcon:MenuItemIconBehavior.IconKind="Ticket" />
+                                                <MenuItem Header="Sửa"
+                                                          itemIcon:MenuItemIconBehavior.IconKind="Edit" />
+                                                <MenuItem Header="Xóa"
+                                                          itemIcon:MenuItemIconBehavior.IconKind="Delete" />
+                                            </ContextMenu>
+                                        </Button.ContextMenu>
                                         <Button.Style>
                                             <Style TargetType="Button">
-                                                <Setter Property="Foreground"
-                                                        Value="{DynamicResource PrimaryTextBrush}" />
-                                                <Setter Property="Padding"
-                                                        Value="5" />
-                                                <Setter Property="Visibility"
-                                                        Value="Collapsed" />
                                                 <Setter Property="Template">
                                                     <Setter.Value>
                                                         <ControlTemplate TargetType="Button">
-                                                            <Border Background="Transparent">
-                                                                <icons:PackIcon x:Name="icon"
-                                                                                Kind="ContentSave"
+                                                            <Grid Background="Transparent"
+                                                                  Height="20">
+                                                                <icons:PackIcon Kind="DotsVertical"
                                                                                 Height="14"
-                                                                                Foreground="{TemplateBinding Foreground}"
                                                                                 Width="14" />
-                                                            </Border>
-                                                            <ControlTemplate.Triggers>
-                                                                <Trigger Property="IsMouseOver"
-                                                                         Value="True">
-                                                                    <Setter Property="Foreground"
-                                                                            Value="{DynamicResource PrimaryBrush}" />
-                                                                    <Setter TargetName="icon"
-                                                                            Property="Kind"
-                                                                            Value="ContentSave" />
-                                                                </Trigger>
-                                                                <Trigger Property="IsPressed"
-                                                                         Value="True">
-                                                                    <Setter Property="Foreground"
-                                                                            Value="{DynamicResource PrimaryBrush}" />
-                                                                    <Setter TargetName="icon"
-                                                                            Property="Kind"
-                                                                            Value="ContentSave" />
-                                                                </Trigger>
-                                                            </ControlTemplate.Triggers>
+                                                            </Grid>
                                                         </ControlTemplate>
                                                     </Setter.Value>
                                                 </Setter>
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}}"
-                                                                 Value="True">
-                                                        <Setter Property="Visibility"
-                                                                Value="Visible" />
-                                                    </DataTrigger>
-                                                </Style.Triggers>
+                                                <Setter Property="Foreground"
+                                                        Value="{DynamicResource PrimaryTextBrush}" />
                                             </Style>
                                         </Button.Style>
                                     </Button>
-                                </StackPanel>
-                                <StackPanel Grid.Column="1"
-                                            Orientation="Vertical"
-                                            Margin="5">
-                                    <TextBlock Text="{Binding Name}"
-                                               TextTrimming="CharacterEllipsis">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Setter Property="Foreground"
-                                                        Value="{DynamicResource PrimaryTextBrush}" />
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}}"
-                                                                 Value="True">
-                                                        <Setter Property="FontWeight"
-                                                                Value="Bold" />
-                                                    </DataTrigger>
-                                                    <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}}"
-                                                                 Value="True">
-                                                        <Setter Property="FontWeight"
-                                                                Value="Bold" />
-                                                        <Setter Property="Foreground"
-                                                                Value="{DynamicResource PrimaryBrush}" />
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
-                                    <TextBlock Margin="0 4 0 0">
-                                        <InlineUIContainer>
-                                            <icons:PackIcon Kind="Update"
-                                                            Height="14"
-                                                            Width="14"
-                                                            Foreground="{DynamicResource SecondaryTextBrush}" />
-                                        </InlineUIContainer>
-                                        <Run Text="{Binding UpdatedAt, StringFormat=': {0:dd/MM/yyyy HH:mm:ss}', TargetNullValue='None'}"
-                                             FontSize="12"
-                                             Foreground="{DynamicResource SecondaryTextBrush}"
-                                             BaselineAlignment="Center" />
-                                    </TextBlock>
-                                </StackPanel>
-                                <Button x:Name="MenuButton"
-                                        Background="Transparent"
-                                        Click="MenuButton_Click"
-                                        Grid.Column="2"
-                                        VerticalAlignment="Top"
-                                        Margin="0 5 10 0"
-                                        Cursor="Hand">
-                                    <Button.ContextMenu>
-                                        <ContextMenu Style="{DynamicResource DP_ContextMenuStyle}">
-                                            <MenuItem Header="Kích hoạt"
-                                                      itemIcon:MenuItemIconBehavior.IconKind="Ticket" />
-                                            <MenuItem Header="Sửa"
-                                                      itemIcon:MenuItemIconBehavior.IconKind="Edit" />
-                                            <MenuItem Header="Xóa"
-                                                      itemIcon:MenuItemIconBehavior.IconKind="Delete" />
-                                        </ContextMenu>
-                                    </Button.ContextMenu>
-                                    <Button.Style>
-                                        <Style TargetType="Button">
-                                            <Setter Property="Template">
-                                                <Setter.Value>
-                                                    <ControlTemplate TargetType="Button">
-                                                        <Grid Background="Transparent"
-                                                              Height="20">
-                                                            <icons:PackIcon Kind="DotsVertical"
-                                                                            Height="14"
-                                                                            Width="14" />
-                                                        </Grid>
-                                                    </ControlTemplate>
-                                                </Setter.Value>
-                                            </Setter>
-                                            <Setter Property="Foreground"
-                                                    Value="{DynamicResource PrimaryTextBrush}" />
-                                        </Style>
-                                    </Button.Style>
-                                </Button>
-                            </Grid>
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
-                </ListView>
+                                </Grid>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                    
+                    <!-- Thông báo khi không tìm thấy kết quả -->
+                    <StackPanel Orientation="Vertical" 
+                                HorizontalAlignment="Center" 
+                                VerticalAlignment="Center"
+                                Margin="20">
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasItems, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}" Value="False">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
+                        
+                        <icons:PackIcon Kind="DatabaseSearchOutline" 
+                                        Height="48" 
+                                        Width="48" 
+                                        Foreground="{DynamicResource SecondaryTextBrush}" 
+                                        HorizontalAlignment="Center" />
+                        <TextBlock Text="Không tìm thấy dự án nào" 
+                                   Foreground="{DynamicResource SecondaryTextBrush}" 
+                                   FontSize="14" 
+                                   HorizontalAlignment="Center" 
+                                   Margin="0 10 0 0" />
+                        <TextBlock Foreground="{DynamicResource ThirdlyTextBrush}" 
+                                   FontSize="10" 
+                                   HorizontalAlignment="Center" 
+                                   Margin="0 5 0 0">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding SearchText, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Converter={StaticResource StringToHasValueConverter}}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                            <Run Text="Thử tìm kiếm với từ khóa khác" />
+                        </TextBlock>
+                    </StackPanel>
+                </Grid>
             </DockPanel>
         </GroupBox>
     </DockPanel>

--- a/src/DPUnity.Wpf.Controls/Controls/ProjectSettingsMenus/ProjectSettingsMenu.xaml.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/ProjectSettingsMenus/ProjectSettingsMenu.xaml.cs
@@ -1,7 +1,11 @@
 ﻿using System.Collections;
+using System.ComponentModel;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
+using System.Windows.Threading;
 
 namespace DPUnity.Wpf.Controls.Controls.ProjectSettingsMenus
 {
@@ -10,19 +14,153 @@ namespace DPUnity.Wpf.Controls.Controls.ProjectSettingsMenus
     /// </summary>
     public partial class ProjectSettingsMenu : UserControl
     {
+        private ICollectionView? _itemsView;
+        private DispatcherTimer? _searchTimer;
+        private const double SEARCH_DELAY_MS = 150;
+
         public ProjectSettingsMenu()
         {
             InitializeComponent();
+            InitializeSearchTimer();
+        }
+
+        private void InitializeSearchTimer()
+        {
+            _searchTimer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(SEARCH_DELAY_MS)
+            };
+            _searchTimer.Tick += OnSearchTimerTick;
+        }
+
+        private void OnSearchTimerTick(object? sender, EventArgs e)
+        {
+            _searchTimer?.Stop();
+            ApplyFilter();
         }
 
         public static readonly DependencyProperty ItemsSourceProperty =
-            DependencyProperty.Register("ItemsSource", typeof(IEnumerable), typeof(ProjectSettingsMenu));
+            DependencyProperty.Register("ItemsSource", typeof(IEnumerable), typeof(ProjectSettingsMenu),
+                new PropertyMetadata(null, OnItemsSourceChanged));
 
         public IEnumerable ItemsSource
         {
             get { return (IEnumerable)GetValue(ItemsSourceProperty); }
             set { SetValue(ItemsSourceProperty, value); }
         }
+
+        private static void OnItemsSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is ProjectSettingsMenu control)
+            {
+                control.SetupCollectionView();
+            }
+        }
+
+        private void SetupCollectionView()
+        {
+            if (ItemsSource != null)
+            {
+                _itemsView = CollectionViewSource.GetDefaultView(ItemsSource);
+                _itemsView.Filter = FilterPredicate;
+                _itemsView.Refresh();
+                HasItems = FilteredItemsCount > 0;
+            }
+            else
+            {
+                _itemsView = null;
+                HasItems = false;
+            }
+        }
+
+        public static readonly DependencyProperty SearchTextProperty =
+            DependencyProperty.Register("SearchText", typeof(string), typeof(ProjectSettingsMenu),
+                new PropertyMetadata(string.Empty, OnSearchTextChanged));
+
+        public string SearchText
+        {
+            get { return (string)GetValue(SearchTextProperty); }
+            set { SetValue(SearchTextProperty, value); }
+        }
+
+        private static void OnSearchTextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is ProjectSettingsMenu control)
+            {
+                control.OnSearchTextChangedInternal();
+            }
+        }
+
+        private void OnSearchTextChangedInternal()
+        {
+            // Dừng timer hiện tại nếu đang chạy
+            _searchTimer?.Stop();
+
+            // Bắt đầu timer mới
+            _searchTimer?.Start();
+        }
+
+        public static readonly DependencyProperty HasItemsProperty =
+            DependencyProperty.Register("HasItems", typeof(bool), typeof(ProjectSettingsMenu),
+                new PropertyMetadata(true));
+
+        public bool HasItems
+        {
+            get { return (bool)GetValue(HasItemsProperty); }
+            set { SetValue(HasItemsProperty, value); }
+        }
+
+        private void ApplyFilter()
+        {
+            if (_itemsView != null)
+            {
+                _itemsView.Refresh();
+                // Cập nhật HasItems để hiển thị thông báo khi không có kết quả
+                HasItems = FilteredItemsCount > 0;
+            }
+            else
+            {
+                HasItems = false;
+            }
+        }
+
+        private bool FilterPredicate(object item)
+        {
+            if (string.IsNullOrWhiteSpace(SearchText))
+                return true;
+
+            // Kiểm tra nếu item có property Name
+            var nameProperty = item?.GetType().GetProperty("Name");
+            if (nameProperty != null)
+            {
+                var name = nameProperty.GetValue(item)?.ToString();
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    return name.IndexOf(SearchText, System.StringComparison.OrdinalIgnoreCase) >= 0;
+                }
+            }
+
+            var descriptionProperty = item?.GetType().GetProperty("Description");
+            if (descriptionProperty != null)
+            {
+                var description = descriptionProperty.GetValue(item)?.ToString();
+                if (!string.IsNullOrWhiteSpace(description))
+                {
+                    return description.IndexOf(SearchText, System.StringComparison.OrdinalIgnoreCase) >= 0;
+                }
+            }
+
+            var itemString = item?.ToString();
+            return !string.IsNullOrWhiteSpace(itemString) &&
+                   itemString.IndexOf(SearchText, System.StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        public void ClearSearch()
+        {
+            SearchText = string.Empty;
+        }
+
+        public int FilteredItemsCount => _itemsView?.Cast<object>().Count() ?? 0;
 
         public static readonly DependencyProperty SelectedItemProperty =
             DependencyProperty.Register(
@@ -56,6 +194,20 @@ namespace DPUnity.Wpf.Controls.Controls.ProjectSettingsMenus
             set { SetValue(SaveCommandProperty, value); }
         }
 
+        public static readonly DependencyProperty CurrentProjectNameProperty =
+            DependencyProperty.Register(
+                "CurrentProjectName",
+                typeof(string),
+                typeof(ProjectSettingsMenu),
+                new FrameworkPropertyMetadata("Chưa chọn dự án", FrameworkPropertyMetadataOptions.BindsTwoWayByDefault)
+            );
+
+        public string CurrentProjectName
+        {
+            get { return (string)GetValue(CurrentProjectNameProperty); }
+            set { SetValue(CurrentProjectNameProperty, value); }
+        }
+
         private void MenuButton_Click(object sender, RoutedEventArgs e)
         {
             if (sender is Button button && button.ContextMenu != null)
@@ -64,6 +216,29 @@ namespace DPUnity.Wpf.Controls.Controls.ProjectSettingsMenus
                 button.ContextMenu.Placement = System.Windows.Controls.Primitives.PlacementMode.Bottom;
                 button.ContextMenu.IsOpen = true;
             }
+        }
+
+        private void Search_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (sender is TextBox textBox)
+            {
+                SearchText = textBox.Text;
+            }
+        }
+    }
+
+    public class StringToHasValueConverter : IValueConverter
+    {
+        public static readonly StringToHasValueConverter Instance = new();
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return !string.IsNullOrWhiteSpace(value?.ToString());
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/DPUnity.Wpf.Controls/DPUnity.Wpf.Controls.csproj
+++ b/src/DPUnity.Wpf.Controls/DPUnity.Wpf.Controls.csproj
@@ -4,9 +4,9 @@
 		<TargetFrameworks>net8.0-windows;net472</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<UseWPF>true</UseWPF>
-		<LangVersion>12.0</LangVersion>
+		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.2</Version>
+		<Version>1.0.3</Version>
 		<PackageId>DPUnity.Wpf.Controls</PackageId>
 		<Title>DPUnity WPF Controls</Title>
 		<Description>Custom WPF controls and components for enhanced user interface development</Description>
@@ -20,14 +20,8 @@
 		<Folder Include="Themes\" />
 	</ItemGroup>
 
-	<!--<ItemGroup>
-    <Reference Include="DPUnity.Wpf.UI">
-      <HintPath>..\..\..\DPUnity.Wpf.UI\bin\Debug\net8.0-windows\DPUnity.Wpf.UI.dll</HintPath>
-    </Reference>
-  </ItemGroup>-->
-
 	<ItemGroup>
-		<PackageReference Include="DPUnity.Wpf.UI" Version="1.0.9" />
+	  <PackageReference Include="DPUnity.Wpf.UI" Version="1.0.10" />
 	</ItemGroup>
 
 


### PR DESCRIPTION
This pull request introduces a new dialog and notification service for WPF controls, adds a workflow for publishing NuGet packages to GitHub Packages, and defines a new interface for project settings menus. The main changes are the addition of a reusable dialog service with both weak (Growl-based) and modal notification support, a custom notification window UI, and CI/CD automation for package publishing and Discord notifications.

**Dialog & Notification Service:**

* Added `DPDialog` static class to provide both weak (Growl) and modal notification dialogs, supporting various types (Info, Success, Error, Warning, Ask) with async and sync methods. (`DPDialog.cs`)
* Implemented a custom modal notification window (`NotificationWindow.xaml` and `NotificationWindow.xaml.cs`) with themed icons, buttons, and support for user interaction (OK/Cancel/Close), including drag-to-move and dynamic styling based on notification type. [[1]](diffhunk://#diff-087749bf9109cc80e01ae80076956c0c4629e0298ab0bcb8de4f042378a37c14R1-R145) [[2]](diffhunk://#diff-4aa69cbdb8a06e0c671ee66a64c26996dc53772645f35075eb9b6eb0794cc7adR1-R109)

**DevOps / CI Automation:**

* Added `.github/workflows/publish.yml` workflow to build, pack, and publish NuGet packages on push to the `nuget` branch, with Discord notifications for success, failure, and duplicate package errors.

**Project Settings:**

* Defined `IDP_ProjectSetting` interface for project settings menus, specifying properties for identification, audit, activation, and a `Save()` method. (`IDP_ProjectSetting.cs`)