### PR TITLE
Improve window ownership handling in DPDialog

### DIFF
--- a/src/DPUnity.Wpf.Controls/DPUnity.Wpf.Controls.csproj
+++ b/src/DPUnity.Wpf.Controls/DPUnity.Wpf.Controls.csproj
@@ -6,7 +6,7 @@
 		<UseWPF>true</UseWPF>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.5</Version>
+		<Version>1.0.6</Version>
 		<PackageId>DPUnity.Wpf.Controls</PackageId>
 		<Title>DPUnity WPF Controls</Title>
 		<Description>Custom WPF controls and components for enhanced user interface development</Description>


### PR DESCRIPTION
This pull request updates the package version in the project file to prepare for a new release.

Versioning:

* Bumped the version of `DPUnity.Wpf.Controls` in `DPUnity.Wpf.Controls.csproj` from `1.0.5` to `1.0.6`.Updated the `DPDialog.cs` to enhance the handling of window ownership by introducing a `try-catch` block for error management. The logic for assigning `mainWindow` has been refined to ensure it is only set if it is not a `NotificationWindow`, preventing potential null reference exceptions.

Also, updated the version number in `DPUnity.Wpf.Controls.csproj` from `1.0.5` to `1.0.6` to reflect these changes.