### PR TITLE
Fix NotificationWindow initialization and update version

### DIFF
--- a/src/DPUnity.Wpf.Controls/Controls/DialogService/Views/NotificationWindow.xaml.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/DialogService/Views/NotificationWindow.xaml.cs
@@ -67,8 +67,8 @@ namespace DPUnity.Wpf.Controls.Controls.DialogService.Views
         {
             try
             {
-                InitializeComponent();
                 LoadResourceDictionaries();
+                InitializeComponent();
 
                 _type = type;
                 _message = message;

--- a/src/DPUnity.Wpf.Controls/DPUnity.Wpf.Controls.csproj
+++ b/src/DPUnity.Wpf.Controls/DPUnity.Wpf.Controls.csproj
@@ -6,7 +6,7 @@
 		<UseWPF>true</UseWPF>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.15</Version>
+		<Version>1.0.16-preview</Version>
 		<PackageId>DPUnity.Wpf.Controls</PackageId>
 		<Title>DPUnity WPF Controls</Title>
 		<Description>Custom WPF controls and components for enhanced user interface development</Description>


### PR DESCRIPTION
This pull request includes a minor version bump for the `DPUnity.Wpf.Controls` package and a small code reordering in the `NotificationWindow` constructor to improve initialization order.

Versioning:

* Updated the package version in `DPUnity.Wpf.Controls.csproj` from `1.0.15` to `1.0.16-preview` to indicate a new preview release.

Code organization:

* Moved the call to `InitializeComponent()` after `LoadResourceDictionaries()` in the `NotificationWindow.xaml.cs` constructor for better initialization sequencing.Updated the `NotificationWindow` constructor to call `InitializeComponent()` before setting properties, ensuring proper UI initialization. Also, bumped the package version from `1.0.15` to `1.0.16-preview` to incorporate potential new features and improvements.