### PR TITLE
Dev

### DIFF
--- a/src/DPUnity.Wpf.Controls/Controls/DialogService/Views/NotificationWindow.xaml.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/DialogService/Views/NotificationWindow.xaml.cs
@@ -211,16 +211,12 @@ namespace DPUnity.Wpf.Controls.Controls.DialogService.Views
         {
             Source = new Uri("pack://application:,,,/DPUnity.WPF.UI;component/Styles/DPUnityResources.xaml")
         };
-        private static ResourceDictionary HandyDict { get; } = new ResourceDictionary
-        {
-            Source = new Uri("pack://application:,,,/DPUnity.WPF.UI;component/Styles/HandyResources.xaml")
-        };
+
         private void LoadResourceDictionaries()
         {
             try
             {
                 this.Resources.MergedDictionaries.Clear();
-                this.Resources.MergedDictionaries.Add(HandyDict);
                 this.Resources.MergedDictionaries.Add(DPUDict);
             }
             catch (Exception ex)

--- a/src/DPUnity.Wpf.Controls/DPUnity.Wpf.Controls.csproj
+++ b/src/DPUnity.Wpf.Controls/DPUnity.Wpf.Controls.csproj
@@ -24,7 +24,7 @@
 
 
 	<ItemGroup>
-	  <PackageReference Include="DPUnity.Wpf.UI" Version="1.0.14-preview-5" />
+	  <PackageReference Include="DPUnity.Wpf.UI" Version="1.0.15" />
 	</ItemGroup>
 
 </Project>

--- a/src/DPUnity.Wpf.Controls/DPUnity.Wpf.Controls.csproj
+++ b/src/DPUnity.Wpf.Controls/DPUnity.Wpf.Controls.csproj
@@ -6,7 +6,7 @@
 		<UseWPF>true</UseWPF>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.17-preview</Version>
+		<Version>1.0.17-preview-1</Version>
 		<PackageId>DPUnity.Wpf.Controls</PackageId>
 		<Title>DPUnity WPF Controls</Title>
 		<Description>Custom WPF controls and components for enhanced user interface development</Description>


### PR DESCRIPTION
This pull request introduces a new publishing workflow for NuGet packages, adds a reusable validation behavior for WPF controls, and implements a comprehensive color picker control in XAML. The main changes are grouped below by theme.

### CI/CD Automation

* Added a new GitHub Actions workflow (`.github/workflows/publish.yml`) to automate building, packing, and publishing the `DPUnity.Wpf.Controls` NuGet package to GitHub Packages. The workflow includes steps for authentication, error handling (including duplicate package detection), and Discord notifications for success or failure.

### WPF Behaviors

* Introduced a static `ValidationBehavior` class (`ValidationBehavior.cs`) with an attached property `ValidateOnSubmit` for WPF controls. This enables validation of a `TextBox`'s binding source when the property is set, improving form validation handling.

### UI Controls

* Added a new `ColorPicker.xaml` user control with a modern, feature-rich UI for color selection. Features include a color canvas, hue and alpha sliders, current color display, RGBA and HEX input modes, default/recent color swatches, and confirm/cancel buttons.
This pull request makes minor updates to the `DPUnity.Wpf.Controls` project, focusing on dependency management and resource dictionary usage. The most significant changes are an upgrade to the `DPUnity.Wpf.UI` package version and a simplification of resource loading in the notification window.

**Dependency Updates:**

* Upgraded the `DPUnity.Wpf.UI` package reference from version `1.0.14-preview-5` to `1.0.15` in `DPUnity.Wpf.Controls.csproj`, ensuring the project uses the latest stable features and bug fixes.
* Updated the project version from `1.0.17-preview` to `1.0.17-preview-1` in `DPUnity.Wpf.Controls.csproj` to reflect the new release and dependency changes.

**Resource Dictionary Management:**

* Removed the static `HandyDict` resource dictionary and its usage in `NotificationWindow.xaml.cs`, simplifying resource management by only merging the `DPUDict` dictionary.