### PR TITLE
Enhance input forms with keyboard support and resizing

### DIFF
--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/DPInput.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/DPInput.cs
@@ -15,7 +15,7 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms
         {
             var windowOptions = new WindowOptions()
             {
-                ResizeMode = ResizeMode.NoResize,
+                ResizeMode = ResizeMode.CanResize,
                 MinWidth = 125,
                 MinHeight = 125,
                 Width = 450,
@@ -40,7 +40,7 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms
                 Width = 300,
                 Height = 160,
                 MinHeight = 160,
-                ResizeMode = ResizeMode.NoResize,
+                ResizeMode = ResizeMode.CanResize,
                 WindowOwner = owner,
                 windowAction = (wd) => { if (owner == 0) { WindowHelper.SetWindowOwner(wd.Window); } }
             };
@@ -69,7 +69,7 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms
                 Width = 400,
                 Height = 140,
                 MinHeight = 140,
-                ResizeMode = ResizeMode.NoResize,
+                ResizeMode = ResizeMode.CanResize,
                 WindowOwner = owner,
                 windowAction = (wd) => { if (owner == 0) { WindowHelper.SetWindowOwner(wd.Window); } }
             };
@@ -96,7 +96,7 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms
                 Width = 400,
                 Height = 160,
                 MinHeight = 160,
-                ResizeMode = ResizeMode.NoResize,
+                ResizeMode = ResizeMode.CanResize,
                 WindowOwner = owner,
                 windowAction = (wd) => { if (owner == 0) { WindowHelper.SetWindowOwner(wd.Window); } }
             };
@@ -136,7 +136,7 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms
                 Width = 400,
                 Height = 120,
                 MinHeight = 120,
-                ResizeMode = ResizeMode.NoResize,
+                ResizeMode = ResizeMode.CanResize,
                 WindowOwner = owner,
                 windowAction = (wd) => { if (owner == 0) { WindowHelper.SetWindowOwner(wd.Window); } }
             };
@@ -191,7 +191,7 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms
                 Width = 400,
                 Height = 200,
                 MinHeight = 200,
-                ResizeMode = ResizeMode.NoResize,
+                ResizeMode = ResizeMode.CanResize,
                 WindowOwner = owner,
                 windowAction = (wd) => { if (owner == 0) { WindowHelper.SetWindowOwner(wd.Window); } }
             };

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/DPInputService.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/DPInputService.cs
@@ -37,7 +37,7 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms
                 Width = 400,
                 Height = 140,
                 MinHeight = 140,
-                ResizeMode = System.Windows.ResizeMode.NoResize,
+                ResizeMode = System.Windows.ResizeMode.CanResize,
             };
             var (Result, ViewModel) = await _windowService.OpenWindowDialogByLoadingAsync<TextInputPage, TextInputViewModel>
                (options, false, (vm) =>
@@ -62,7 +62,7 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms
                 Width = 400,
                 Height = 160,
                 MinHeight = 160,
-                ResizeMode = System.Windows.ResizeMode.NoResize,
+                ResizeMode = System.Windows.ResizeMode.CanResize,
             };
             var (Result, ViewModel) = await _windowService.OpenWindowDialogByLoadingAsync<NumericInputPage, NumericInputViewModel>
                (options, false, (vm) =>
@@ -100,7 +100,7 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms
                 Width = 400,
                 Height = 130,
                 MinHeight = 130,
-                ResizeMode = System.Windows.ResizeMode.NoResize,
+                ResizeMode = System.Windows.ResizeMode.CanResize,
             };
             var (Result, ViewModel) = await _windowService.OpenWindowDialogByLoadingAsync<SelectInputPage, SelectInputViewModel>
                (options, false, (vm) =>
@@ -151,7 +151,7 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms
                 Width = 400,
                 Height = 160,
                 MinHeight = 160,
-                ResizeMode = System.Windows.ResizeMode.NoResize,
+                ResizeMode = System.Windows.ResizeMode.CanResize,
             };
             var (Result, ViewModel) = await _windowService.OpenWindowDialogByLoadingAsync<BooleanInputPage, BooleanInputViewModel>
                (options, false, (vm) =>
@@ -178,7 +178,7 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms
                 Width = 400,
                 Height = 200,
                 MinHeight = 200,
-                ResizeMode = System.Windows.ResizeMode.NoResize,
+                ResizeMode = System.Windows.ResizeMode.CanResize,
             };
             var (Result, ViewModel) = await _windowService.OpenWindowDialogByLoadingAsync<ReplaceInputPage, ReplaceInputViewModel>
                (options, false, (vm) =>
@@ -228,7 +228,7 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms
         {
             var windowOptions = new WindowOptions()
             {
-                ResizeMode = ResizeMode.NoResize,
+                ResizeMode = ResizeMode.CanResize,
                 MinWidth = 125,
                 MinHeight = 125,
                 Width = 450,

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/BooleanInputPage.xaml
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/BooleanInputPage.xaml
@@ -6,28 +6,39 @@
           xmlns:local="clr-namespace:DPUnity.Wpf.Controls.Controls.InputForms.Forms"
           xmlns:wd="https://dpunity.com/dev/wpf/windows"
           xmlns:hc="https://handyorg.github.io/handycontrol"
+          xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
           mc:Ignorable="d"
           d:DesignHeight="450"
           d:DesignWidth="800"
-          Title="BooleanInputPage">
+          Title="BooleanInputPage"
+          Loaded="DPage_Loaded">
+    <i:Interaction.Triggers>
+        <i:EventTrigger EventName="PreviewKeyDown">
+            <i:InvokeCommandAction Command="{Binding KeyDownCommand}"
+                                   PassEventArgsToCommand="True" />
+        </i:EventTrigger>
+    </i:Interaction.Triggers>
+
     <Grid Margin="10 5">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
-            <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-
-        <RadioButton IsChecked="{Binding Value}"
-                     Content="{Binding TrueContent}"
-                     GroupName="BooleanInput"
-                     HorizontalAlignment="Left"
-                     Padding="5 3" />
-
-        <RadioButton Content="{Binding FalseContent}"
-                     GroupName="BooleanInput"
-                     HorizontalAlignment="Left"
-                     Grid.Row="1"
-                     Padding="5 3" />
+        <hc:UniformSpacingPanel Spacing="10"
+                                Orientation="Vertical"
+                                KeyboardNavigation.TabNavigation="Cycle">
+            <RadioButton x:Name="TrueRadio"
+                         IsChecked="{Binding Value}"
+                         Content="{Binding TrueContent}"
+                         GroupName="BooleanInput"
+                         HorizontalAlignment="Left"
+                         Padding="5 3" />
+            <RadioButton x:Name="FalseRadio"
+                         Content="{Binding FalseContent}"
+                         GroupName="BooleanInput"
+                         HorizontalAlignment="Left"
+                         Padding="5 3" />
+        </hc:UniformSpacingPanel>
         <hc:UniformSpacingPanel Spacing="10"
                                 Orientation="Horizontal"
                                 Grid.Row="2"
@@ -35,7 +46,6 @@
                                 Margin=" 0 0 0 10">
             <Button Content="OK"
                     Width="75"
-                    IsDefault="True"
                     Command="{Binding SubmitCommand}" />
             <Button Content="Cancel"
                     Width="75"

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/BooleanInputPage.xaml.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/BooleanInputPage.xaml.cs
@@ -11,5 +11,24 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
         {
             InitializeComponent();
         }
+
+        private void DPage_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            if (DataContext is BooleanInputViewModel vm)
+            {
+                vm.Value = true;
+
+                if (TrueRadio != null)
+                {
+                    TrueRadio.GotFocus += (s, args) => vm.Value = true;
+                    TrueRadio.Focus();
+                }
+
+                if (FalseRadio != null)
+                {
+                    FalseRadio.GotFocus += (s, args) => FalseRadio.IsChecked = true;
+                }
+            }
+        }
     }
 }

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/BooleanInputViewModel.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/BooleanInputViewModel.cs
@@ -2,13 +2,14 @@
 using CommunityToolkit.Mvvm.Input;
 using DPUnity.Windows;
 using DPUnity.Windows.Services;
+using System.Windows.Input;
 
 namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
 {
     public partial class BooleanInputViewModel : ViewModelPage
     {
         [ObservableProperty]
-        private bool value;
+        private bool value = true;
 
         [ObservableProperty]
         private string trueContent = "True";
@@ -18,13 +19,32 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
 
         public BooleanInputViewModel(IWindowService windowService, INavigationService navigationService) : base(windowService, navigationService)
         {
-
         }
 
         [RelayCommand]
-        public void Submit()
+        private void Submit()
         {
             OK();
+        }
+
+        [RelayCommand]
+        private void KeyDown(EventArgs e)
+        {
+            if (e is not KeyEventArgs keyEventArgs) return;
+            switch (keyEventArgs.Key)
+            {
+                case Key.Space:
+                case Key.Enter:
+                    // Enter key submits the form
+                    OK();
+                    keyEventArgs.Handled = true;
+                    break;
+                case Key.Escape:
+                    // Escape key cancels the form
+                    Cancel();
+                    keyEventArgs.Handled = true;
+                    break;
+            }
         }
     }
 }

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/DataGridReplaceInputPage.xaml
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/DataGridReplaceInputPage.xaml
@@ -10,7 +10,15 @@
           mc:Ignorable="d"
           d:DesignHeight="500"
           d:DesignWidth="800"
-          Title="DataGridReplaceInputPage">
+          Title="DataGridReplaceInputPage"
+          Loaded="DPage_Loaded">
+    <i:Interaction.Triggers>
+        <i:EventTrigger EventName="PreviewKeyDown">
+            <i:InvokeCommandAction Command="{Binding KeyDownCommand}"
+                                   PassEventArgsToCommand="True" />
+        </i:EventTrigger>
+    </i:Interaction.Triggers>
+
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -46,7 +54,8 @@
                           hc:InfoElement.Placeholder="Tìm kiếm"
                           hc:InfoElement.ShowClearButton="True"
                         Style="{DynamicResource TextBoxPlusBaseStyle}"
-                          Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+                        Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                        x:Name="Search" />
             <Button Content="Sort"
                     Grid.Column="1"
                     Style="{DynamicResource DP_IconButtonStyle}" 

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/DataGridReplaceInputPage.xaml.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/DataGridReplaceInputPage.xaml.cs
@@ -1,6 +1,5 @@
 using DPUnity.Windows;
 using System.Windows.Controls;
-using System.Linq;
 
 namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
 {
@@ -31,7 +30,12 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
             {
                 var selectedItems = listView.SelectedItems.Cast<DataGridColumn>();
                 ViewModel.OnRightSelectionChanged(selectedItems);
-            } 
+            }
+        }
+
+        private void DPage_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            Search.Focus();
         }
     }
 }

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/DataGridReplaceInputViewModel.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/DataGridReplaceInputViewModel.cs
@@ -4,6 +4,7 @@ using DPUnity.Windows;
 using DPUnity.Windows.Services;
 using System.Collections.ObjectModel;
 using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
 {
@@ -306,6 +307,26 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
                     _allColumns.Add(column);
                     ColumnsSource.Add(column);
                 }
+            }
+        }
+
+        [RelayCommand]
+        private void KeyDown(EventArgs e)
+        {
+            if (e is not KeyEventArgs keyEventArgs) return;
+            switch (keyEventArgs.Key)
+            {
+                case Key.Enter:
+                    if (CanSubmit())
+                    {
+                        OK();
+                        keyEventArgs.Handled = true;
+                    }
+                    break;
+                case Key.Escape:
+                    Cancel();
+                    keyEventArgs.Handled = true;
+                    break;
             }
         }
     }

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/MultiSelectInputPage.xaml
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/MultiSelectInputPage.xaml
@@ -10,7 +10,14 @@
           mc:Ignorable="d"
           d:DesignHeight="450"
           d:DesignWidth="800"
-          Title="MultiSelectInputPage">
+          Title="MultiSelectInputPage"
+          Loaded="DPage_Loaded">
+    <i:Interaction.Triggers>
+        <i:EventTrigger EventName="PreviewKeyDown">
+            <i:InvokeCommandAction Command="{Binding KeyDownCommand}"
+                                   PassEventArgsToCommand="True" />
+        </i:EventTrigger>
+    </i:Interaction.Triggers>
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -29,15 +36,17 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <hc:SearchBar Margin="0 10 5 10"
-                          hc:InfoElement.Placeholder="Tìm kiếm"
-                          hc:InfoElement.ShowClearButton="True"
-                          Style="{DynamicResource SearchBarExtendBaseStyle}"
-                          Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+            <hc:TextBox x:Name="Search"
+                        Margin="0 10 5 10"
+                        hc:InfoElement.Placeholder="Tìm kiếm"
+                        hc:InfoElement.ShowClearButton="True"
+                        Style="{DynamicResource TextBoxPlusBaseStyle}"
+                        Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+
             <Button Content="Sort"
                     Grid.Column="1"
-                    Style="{DynamicResource DP_IconButtonStyle}" 
-                    Command="{Binding LeftSortCommand}"/>
+                    Style="{DynamicResource DP_IconButtonStyle}"
+                    Command="{Binding LeftSortCommand}" />
         </Grid>
         <Grid Grid.Row="1"
               Grid.Column="2">
@@ -45,15 +54,15 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <hc:SearchBar Margin="0 10 5 10"
-                          hc:InfoElement.Placeholder="Tìm kiếm"
-                          hc:InfoElement.ShowClearButton="True"
-                          Style="{DynamicResource SearchBarExtendBaseStyle}"
-                          Text="{Binding SelectedSearchText, UpdateSourceTrigger=PropertyChanged}" />
+            <hc:TextBox Margin="0 10 5 10"
+                     hc:InfoElement.Placeholder="Tìm kiếm"
+                     hc:InfoElement.ShowClearButton="True"
+                     Style="{DynamicResource TextBoxPlusBaseStyle}"
+                     Text="{Binding SelectedSearchText, UpdateSourceTrigger=PropertyChanged}" />
             <Button Content="Sort"
                     Grid.Column="1"
-                    Style="{DynamicResource DP_IconButtonStyle}" 
-                    Command="{Binding RightSortCommand}"/>
+                    Style="{DynamicResource DP_IconButtonStyle}"
+                    Command="{Binding RightSortCommand}" />
         </Grid>
 
         <Grid Grid.Row="2">
@@ -147,7 +156,7 @@
                 </TextBlock.Style>
             </TextBlock>
         </Grid>
-        
+
         <hc:UniformSpacingPanel Grid.Row="2"
                                 Spacing="3"
                                 Orientation="Vertical"
@@ -169,7 +178,7 @@
                     Content="ArrowExpandLeft"
                     Command="{Binding MoveLeftAllCommand}" />
         </hc:UniformSpacingPanel>
-        
+
         <Grid Grid.Row="2"
               Grid.Column="2">
             <ListView x:Name="RightListView"
@@ -264,7 +273,7 @@
                 </TextBlock.Style>
             </TextBlock>
         </Grid>
-        
+
         <hc:UniformSpacingPanel Spacing="5"
                                 Grid.Row="3"
                                 Grid.ColumnSpan="3"

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/MultiSelectInputPage.xaml.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/MultiSelectInputPage.xaml.cs
@@ -31,7 +31,12 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
             {
                 var selectedItems = listView.SelectedItems.Cast<IInputObject>();
                 ViewModel.OnRightSelectionChanged(selectedItems);
-            } 
+            }
+        }
+
+        private void DPage_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            Search.Focus();
         }
     }
 }

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/MultiSelectInputViewModel.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/MultiSelectInputViewModel.cs
@@ -4,6 +4,7 @@ using DPUnity.Windows;
 using DPUnity.Windows.Services;
 using DPUnity.Wpf.Controls.Controls.InputForms.Interfaces;
 using System.Collections.ObjectModel;
+using System.Windows.Input;
 
 namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
 {
@@ -236,6 +237,23 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
             {
                 _selectedItemsInRight.Add(item);
             }
+        }
+
+        [RelayCommand]
+        private void KeyDown(EventArgs e)
+        {
+            if (e is KeyEventArgs keyEvent)
+            {
+                if (keyEvent.Key == Key.Enter)
+                {
+                    Submit();
+                }
+                else if (keyEvent.Key == Key.Escape)
+                {
+                    Cancel();
+                }
+            }
+
         }
     }
 }

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/NumericInputPage.xaml
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/NumericInputPage.xaml
@@ -7,9 +7,17 @@
           xmlns:wd="https://dpunity.com/dev/wpf/windows"
           xmlns:hc="https://handyorg.github.io/handycontrol"
           xmlns:cvt="clr-namespace:DPUnity.Wpf.Controls.Converters"
+          xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
           mc:Ignorable="d"
           d:DesignHeight="200"
-          d:DesignWidth="400">
+          d:DesignWidth="400"
+          Loaded="DPage_Loaded">
+    <i:Interaction.Triggers>
+        <i:EventTrigger EventName="PreviewKeyDown">
+            <i:InvokeCommandAction Command="{Binding KeyDownCommand}"
+                                   PassEventArgsToCommand="True" />
+        </i:EventTrigger>
+    </i:Interaction.Triggers>
     <Page.Resources>
         <cvt:BooleanToHiddenVisibilityConverter x:Key="BooleanToHiddenVisibilityConverter" />
     </Page.Resources>

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/NumericInputPage.xaml.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/NumericInputPage.xaml.cs
@@ -51,5 +51,10 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
             // Kiểm tra range validation
             return viewModel.IsValidInputForRange(currentText, input, caretIndex);
         }
+
+        private void DPage_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            NumericTextBox.Focus();
+        }
     }
 }

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/NumericInputViewModel.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/NumericInputViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using DPUnity.Windows;
 using DPUnity.Windows.Services;
 using System.Globalization;
+using System.Windows.Input;
 
 namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
 {
@@ -185,6 +186,24 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
                 return false;
 
             return true;
+        }
+
+        [RelayCommand]
+        private void KeyDown(EventArgs e)
+        {
+            if (e is KeyEventArgs keyEvent)
+            {
+                if (keyEvent.Key == Key.Enter && CanSubmit())
+                {
+                    Submit();
+                    keyEvent.Handled = true;
+                }
+                else if (keyEvent.Key == Key.Escape)
+                {
+                    Cancel();
+                    keyEvent.Handled = true;
+                }
+            }
         }
     }
 }

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/ProcessPage.xaml
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/ProcessPage.xaml
@@ -1,13 +1,15 @@
 ﻿<wd:ProcessPage x:Class="DPUnity.Wpf.Controls.Controls.InputForms.Forms.ProcessPage"
-      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-      xmlns:local="clr-namespace:DPUnity.Wpf.Controls.Controls.InputForms.Forms"
-      xmlns:wd="https://dpunity.com/dev/wpf/windows"
-      mc:Ignorable="d" 
-      d:DesignHeight="100" d:DesignWidth="800"
-      Title="ProcessPage">
+                xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                xmlns:local="clr-namespace:DPUnity.Wpf.Controls.Controls.InputForms.Forms"
+                xmlns:wd="https://dpunity.com/dev/wpf/windows"
+                xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
+                mc:Ignorable="d"
+                d:DesignHeight="100"
+                d:DesignWidth="800"
+                Title="ProcessPage">
 
     <Grid>
         <Grid.RowDefinitions>
@@ -25,13 +27,15 @@
                    VerticalAlignment="Center"
                    Grid.Row="1"
                    HorizontalAlignment="Right"
-                   Grid.Column="1">
+                   Grid.Column="1"
+                   KeyboardNavigation.TabNavigation="Cycle">
             <Button  Content="Cancel"
+                     IsDefault="True"
+                     x:Name="CancelButton"
                      Command="{Binding CancelCommand}"
                      Width="80"
                      Height="30"
-                     Margin="0 0 10 0"/>
-
+                     Margin="0 0 10 0" />
         </DockPanel>
     </Grid>
 </wd:ProcessPage>

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/ProcessPage.xaml.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/ProcessPage.xaml.cs
@@ -10,6 +10,7 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
         public ProcessPage(ProcessViewModel processViewModel) : base(processViewModel)
         {
             InitializeComponent();
+            CancelButton.Focus();
         }
     }
 }

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/ReplaceInputPage.xaml
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/ReplaceInputPage.xaml
@@ -6,9 +6,19 @@
           xmlns:local="clr-namespace:DPUnity.Wpf.Controls.Controls.InputForms.Forms"
           xmlns:wd="https://dpunity.com/dev/wpf/windows"
           xmlns:hc="https://handyorg.github.io/handycontrol"
+          xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
           mc:Ignorable="d"
           d:DesignHeight="500"
-          d:DesignWidth="400">
+          d:DesignWidth="400"
+          Loaded="DPage_Loaded">
+
+    <i:Interaction.Triggers>
+        <i:EventTrigger EventName="PreviewKeyDown">
+            <i:InvokeCommandAction Command="{Binding KeyDownCommand}"
+                                   PassEventArgsToCommand="True" />
+        </i:EventTrigger>
+    </i:Interaction.Triggers>
+
     <Grid Margin="5">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -21,7 +31,7 @@
         <TextBlock Text="Replace:"
                    Margin="0 0 0 5" />
         
-        <hc:TextBox Text="{Binding Replace, UpdateSourceTrigger=PropertyChanged}"
+        <hc:TextBox x:Name="ReplaceTextBox" Text="{Binding Replace, UpdateSourceTrigger=PropertyChanged}"
                     Style="{DynamicResource TextBoxExtend}"
                     Height="28"
                     Grid.Row="1" />

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/ReplaceInputPage.xaml.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/ReplaceInputPage.xaml.cs
@@ -11,5 +11,10 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
         {
             InitializeComponent();
         }
+
+        private void DPage_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            ReplaceTextBox.Focus();
+        }
     }
 }

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/ReplaceInputViewModel.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/ReplaceInputViewModel.cs
@@ -41,5 +41,20 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
         {
             base.Cancel();
         }
+
+        [RelayCommand]
+        private void KeyDown(System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Enter && CanSubmit())
+            {
+                Submit();
+                e.Handled = true;
+            }
+            else if (e.Key == System.Windows.Input.Key.Escape)
+            {
+                Cancel();
+                e.Handled = true;
+            }
+        }
     }
 }

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/SelectInputPage.xaml
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/SelectInputPage.xaml
@@ -6,17 +6,24 @@
           xmlns:local="clr-namespace:DPUnity.Wpf.Controls.Controls.InputForms.Forms"
           xmlns:wd="https://dpunity.com/dev/wpf/windows"
           xmlns:hc="https://handyorg.github.io/handycontrol"
+          xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
           mc:Ignorable="d"
           d:DesignHeight="450"
           d:DesignWidth="800"
-          Title="SelectInputPage">
-
+          Title="SelectInputPage"
+          Loaded="DPage_Loaded">
+    <i:Interaction.Triggers>
+        <i:EventTrigger EventName="PreviewKeyDown">
+            <i:InvokeCommandAction Command="{Binding KeyDownCommand}"
+                                   PassEventArgsToCommand="True" />
+        </i:EventTrigger>
+    </i:Interaction.Triggers>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <hc:ComboBox ItemsSource="{Binding ItemsSource}"
+        <hc:ComboBox x:Name="SelectCombobox" ItemsSource="{Binding ItemsSource}"
                      IsTextSearchEnabled="True"
                      SelectedItem="{Binding SelectedItem}"
                      SelectedIndex="{Binding SelectedIndex, Mode=OneWayToSource}"

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/SelectInputPage.xaml.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/SelectInputPage.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using DPUnity.Windows;
-using DPUnity.Wpf.Controls.Controls.InputForms.Interfaces;
 
 namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
 {
@@ -11,6 +10,11 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
         public SelectInputPage(SelectInputViewModel vm) : base(vm)
         {
             InitializeComponent();
+        }
+
+        private void DPage_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            SelectCombobox.Focus();
         }
     }
 }

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/SelectInputViewModel.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/SelectInputViewModel.cs
@@ -37,5 +37,20 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
         {
             SubmitCommand.NotifyCanExecuteChanged();
         }
+
+        [RelayCommand]
+        private void KeyDown(System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Enter && CanSubmit())
+            {
+                Submit();
+                e.Handled = true;
+            }
+            else if (e.Key == System.Windows.Input.Key.Escape)
+            {
+                Cancel();
+                e.Handled = true;
+            }
+        }
     }
 }

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/TextInputPage.xaml
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/TextInputPage.xaml
@@ -6,10 +6,17 @@
           xmlns:local="clr-namespace:DPUnity.Wpf.Controls.Controls.InputForms.Forms"
           xmlns:wd="https://dpunity.com/dev/wpf/windows"
           xmlns:hc="https://handyorg.github.io/handycontrol"
+          xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
           mc:Ignorable="d"
           d:DesignHeight="200"
-          d:DesignWidth="400">
-
+          d:DesignWidth="400"
+          Loaded="DPage_Loaded">
+    <i:Interaction.Triggers>
+        <i:EventTrigger EventName="PreviewKeyDown">
+            <i:InvokeCommandAction Command="{Binding KeyDownCommand}"
+                                   PassEventArgsToCommand="True" />
+        </i:EventTrigger>
+    </i:Interaction.Triggers>
     <Grid Margin="5">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
@@ -17,6 +24,7 @@
         </Grid.RowDefinitions>
         <hc:TextBox Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}"
                     Style="{DynamicResource TextBoxExtend}"
+                    Name="InputTextBox"
                     Height="28"/>
         <hc:UniformSpacingPanel Spacing="10" Orientation="Horizontal"
                                 Grid.Row="1"

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/TextInputPage.xaml.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/TextInputPage.xaml.cs
@@ -11,5 +11,10 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
         {
             InitializeComponent();
         }
+
+        private void DPage_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            InputTextBox.Focus();
+        }
     }
 }

--- a/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/TextInputViewModel.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/InputForms/Forms/TextInputViewModel.cs
@@ -30,5 +30,20 @@ namespace DPUnity.Wpf.Controls.Controls.InputForms.Forms
         {
             base.Cancel();
         }
+
+        [RelayCommand]
+        private void KeyDown(System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Enter)
+            {
+                Submit();
+                e.Handled = true;
+            }
+            else if (e.Key == System.Windows.Input.Key.Escape)
+            {
+                Cancel();
+                e.Handled = true;
+            }
+        }
     }
 }

--- a/src/DPUnity.Wpf.Controls/DPUnity.Wpf.Controls.csproj
+++ b/src/DPUnity.Wpf.Controls/DPUnity.Wpf.Controls.csproj
@@ -6,7 +6,7 @@
 		<UseWPF>true</UseWPF>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.25</Version>
+		<Version>1.0.26</Version>
 		<PackageId>DPUnity.Wpf.Controls</PackageId>
 		<Title>DPUnity WPF Controls</Title>
 		<Description>Custom WPF controls and components for enhanced user interface development</Description>


### PR DESCRIPTION
- Changed `ResizeMode` to `CanResize` for various windows.
- Added `Loaded` event handlers to set initial focus on controls.
- Initialized `Value` in `BooleanInputViewModel` to
This pull request introduces several usability improvements to the input dialog windows in the DPUnity WPF controls, focusing on better keyboard accessibility and user experience. The main changes allow users to resize input dialogs, add keyboard shortcuts for submitting/canceling forms, and improve initial focus handling for faster interaction.

**Window Resizability Enhancements:**
* All input dialog windows in both `DPInput` and `DPInputService` classes now support resizing by changing the `ResizeMode` from `NoResize` to `CanResize`, making dialogs more flexible for users. [[1]](diffhunk://#diff-36913014e5704bf6b4640f2481eb6c56c50b1f57792049c14c4e505332e89590L18-R18) [[2]](diffhunk://#diff-36913014e5704bf6b4640f2481eb6c56c50b1f57792049c14c4e505332e89590L43-R43) [[3]](diffhunk://#diff-36913014e5704bf6b4640f2481eb6c56c50b1f57792049c14c4e505332e89590L72-R72) [[4]](diffhunk://#diff-36913014e5704bf6b4640f2481eb6c56c50b1f57792049c14c4e505332e89590L99-R99) [[5]](diffhunk://#diff-36913014e5704bf6b4640f2481eb6c56c50b1f57792049c14c4e505332e89590L139-R139) [[6]](diffhunk://#diff-36913014e5704bf6b4640f2481eb6c56c50b1f57792049c14c4e505332e89590L194-R194) [[7]](diffhunk://#diff-877bf1f94b33e6226bb6c11b9d9b5a7c47db25b790cc8adac757707fb6384e78L40-R40) [[8]](diffhunk://#diff-877bf1f94b33e6226bb6c11b9d9b5a7c47db25b790cc8adac757707fb6384e78L65-R65) [[9]](diffhunk://#diff-877bf1f94b33e6226bb6c11b9d9b5a7c47db25b790cc8adac757707fb6384e78L103-R103) [[10]](diffhunk://#diff-877bf1f94b33e6226bb6c11b9d9b5a7c47db25b790cc8adac757707fb6384e78L154-R154) [[11]](diffhunk://#diff-877bf1f94b33e6226bb6c11b9d9b5a7c47db25b790cc8adac757707fb6384e78L181-R181) [[12]](diffhunk://#diff-877bf1f94b33e6226bb6c11b9d9b5a7c47db25b790cc8adac757707fb6384e78L231-R231)

**Keyboard Accessibility & Shortcuts:**
* Added key event triggers and command bindings in the XAML files (`BooleanInputPage`, `DataGridReplaceInputPage`, `MultiSelectInputPage`) to handle keyboard shortcuts such as Enter (submit), Escape (cancel), and Space (toggle selection). [[1]](diffhunk://#diff-b0f79fe41480f24b392e496d61e0187f1540fdc603d30b4ad375fd5809889862R9-L38) [[2]](diffhunk://#diff-352d2bd3e0651c93928b6ea6bf6e518a7b7a1e4a6cdc5e23ed40a7c6790f3717L13-R21) [[3]](diffhunk://#diff-ca0752fe49f6689ef314c1a8b0ce3a65b51dda632c0805bfaacc572354eb8d6cL13-R20)
* Implemented corresponding `KeyDownCommand` logic in the view models to process these shortcuts, improving efficiency for keyboard users. [[1]](diffhunk://#diff-aa712437e0dd26bc825f383efa5e61a33b0ccc3c12b4ca4d5884397d89e876a3R22-R47) [[2]](diffhunk://#diff-c88b907bf44ddbb2703dc3bd9757c7fb6590bb9ff551798cb1828f07769bcbb0R312-R331)

**Initial Focus Improvements:**
* On dialog load, the most relevant input control (e.g., search box or the "True" radio button) is automatically focused, allowing users to start typing immediately without extra clicks. [[1]](diffhunk://#diff-8cc799afa7b387599082e66d081f4f4682590757d2ccf034aff07260e574e7ffR14-R32) [[2]](diffhunk://#diff-928b4ab9db0e773c0a7985d7d503ca0c4676a3bfdf73aaa9e753d33c3e8b6e42R35-R39) [[3]](diffhunk://#diff-301c827d5ae1990f0bb2e74570fa9302b5a2d9ce765b4e13befeacf6b771b712R36-R40)

**UI Consistency and Minor Refactoring:**
* Replaced custom `SearchBar` controls with styled `TextBox` controls for search inputs in multi-select dialogs to unify appearance and behavior. [[1]](diffhunk://#diff-ca0752fe49f6689ef314c1a8b0ce3a65b51dda632c0805bfaacc572354eb8d6cL32-R45) [[2]](diffhunk://#diff-ca0752fe49f6689ef314c1a8b0ce3a65b51dda632c0805bfaacc572354eb8d6cL48-R60) [[3]](diffhunk://#diff-352d2bd3e0651c93928b6ea6bf6e518a7b7a1e4a6cdc5e23ed40a7c6790f3717L49-R58)
* Set the default value of boolean inputs to `true` for better predictability.

These changes collectively make the input dialogs more user-friendly, especially for users who rely on keyboard navigation and accessibility features. `true` and added `KeyDown` command for keyboard interactions.
- Updated XAML files to include `Interaction.Triggers` for key event handling.
- Set focus on `CancelButton` in `ProcessPage` initialization.
- Incremented project version from `1.0.25` to `1.0.26`.