### PR TITLE
Refactor resource loading in NotificationPage

### DIFF
--- a/src/DPUnity.Wpf.Controls/Controls/DialogService/Views/NotificationPage.xaml
+++ b/src/DPUnity.Wpf.Controls/Controls/DialogService/Views/NotificationPage.xaml
@@ -15,11 +15,7 @@
 
     <wd:DPage.Resources>
         <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="pack://application:,,,/DPUnity.WPF.UI;component/Styles/DPUnityResources.xaml" />
-            </ResourceDictionary.MergedDictionaries>
-
-                <Color x:Key="AskColor">#d9a3d2</Color>
+            <Color x:Key="AskColor">#d9a3d2</Color>
             <SolidColorBrush x:Key="AskBrush"
                              Color="{DynamicResource AskColor}" />
 

--- a/src/DPUnity.Wpf.Controls/Controls/DialogService/Views/NotificationPage.xaml.cs
+++ b/src/DPUnity.Wpf.Controls/Controls/DialogService/Views/NotificationPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using DPUnity.Windows;
+using System.Windows;
 using System.Windows.Input;
 using static DPUnity.Wpf.Controls.Controls.DialogService.DPDialog;
 
@@ -10,8 +11,10 @@ namespace DPUnity.Wpf.Controls.Controls.DialogService.Views
     public partial class NotificationPage : DPage
     {
         public NotificationViewModel NotiViewModel => (NotificationViewModel)ViewModel;
+
         public NotificationPage(NotificationViewModel vm) : base(vm)
         {
+            LoadResourceDictionaries();
             InitializeComponent();
             Loaded += OnLoaded;
             PreviewKeyDown += OnKeyDown;
@@ -87,6 +90,24 @@ namespace DPUnity.Wpf.Controls.Controls.DialogService.Views
             {
                 // Trường hợp không phải Ask: Enter/Space => đóng form
                 NotiViewModel.CloseCommand.Execute(null);
+            }
+        }
+
+        private static ResourceDictionary DPUDict { get; } = new ResourceDictionary
+        {
+            Source = new Uri("pack://application:,,,/DPUnity.WPF.UI;component/Styles/DPUnityResources.xaml")
+        };
+
+        private void LoadResourceDictionaries()
+        {
+            try
+            {
+                this.Resources.MergedDictionaries.Clear();
+                this.Resources.MergedDictionaries.Add(DPUDict);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Warning: Could not load resource dictionaries: {ex.Message}");
             }
         }
     }

--- a/src/DPUnity.Wpf.Controls/DPUnity.Wpf.Controls.csproj
+++ b/src/DPUnity.Wpf.Controls/DPUnity.Wpf.Controls.csproj
@@ -6,7 +6,7 @@
 		<UseWPF>true</UseWPF>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.27-preview</Version>
+		<Version>1.0.27-preview-1</Version>
 		<PackageId>DPUnity.Wpf.Controls</PackageId>
 		<Title>DPUnity WPF Controls</Title>
 		<Description>Custom WPF controls and components for enhanced user interface development</Description>


### PR DESCRIPTION
This pull request updates the `NotificationPage` control to more reliably load its required resource dictionaries at runtime, and bumps the package version. The key change is moving the loading of the `DPUnityResources.xaml` resource dictionary from XAML to code-behind, improving robustness and error handling.

**Resource Dictionary Management:**

* Removed the merged resource dictionary reference to `DPUnityResources.xaml` from `NotificationPage.xaml` and now load it programmatically in the constructor of `NotificationPage`. This ensures the resource dictionary is loaded at runtime and adds error handling if loading fails. [[1]](diffhunk://#diff-22f96ed2f3e1e40705caa96c649490228a837bf934f6cc88cec6515cd9cd3fa4L18-L21) [[2]](diffhunk://#diff-d668dee521f90121eff19e4d381c957773f4f943f8f5fca523b3ce8c8d08e78bR14-R17) [[3]](diffhunk://#diff-d668dee521f90121eff19e4d381c957773f4f943f8f5fca523b3ce8c8d08e78bR95-R112)

**Project Versioning:**

* Updated the NuGet package version in `DPUnity.Wpf.Controls.csproj` from `1.0.27-preview` to `1.0.27-preview-1`.Updated NotificationPage.xaml to implement a new method for loading resource dictionaries, replacing the existing approach with a static resource dictionary (`DPUDict`). The constructor now calls `LoadResourceDictionaries()` to ensure resources are loaded during initialization. Also updated the project version in DPUnity.Wpf.Controls.csproj from `1.0.27-preview` to `1.0.27-preview-1`.